### PR TITLE
fixed missing top level case for editing choice requirements

### DIFF
--- a/src/lib/cyoa/Object.svelte
+++ b/src/lib/cyoa/Object.svelte
@@ -35,7 +35,7 @@
 	import Requirement from './row/Requirement.svelte';
 	import ObjectSettings from './object/ObjectSettings.svelte';
 	import ObjectAddon from './object/ObjectAddon.svelte';
-	import ObjectRequirement from './object/ObjectRequirement.svelte';
+	import ObjectRequirements from './object/ObjectRequirements.svelte';
 	import DOMPurify from 'dompurify';
 	import { onMount } from 'svelte';
 	import WrappedSelect from '$lib/components/wrapped/WrappedSelect.svelte';
@@ -714,7 +714,7 @@
 										)}
 									>
 										<div class="flex flex-col">
-											<ObjectRequirement obj={object} {required} />
+											<ObjectRequirements obj={object} {required} />
 											<Button
 												onclick={() => {
 													const idx = object.requireds.indexOf(required);

--- a/src/lib/cyoa/object/ObjectRequirement.svelte
+++ b/src/lib/cyoa/object/ObjectRequirement.svelte
@@ -1,15 +1,10 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui/button';
-	import { Checkbox } from '$lib/components/ui/checkbox';
-	import { Label } from '$lib/components/ui/label';
 	import type { Object, Requireds, Row } from '$lib/store/types';
-	import { KeyRound } from 'lucide-svelte';
-	import Requirement from '../row/Requirement.svelte';
 	import { app } from '$lib/store/store.svelte';
 	import WrappedSelect from '$lib/components/wrapped/WrappedSelect.svelte';
 	import WrappedInput from '$lib/components/wrapped/WrappedInput.svelte';
 
-	const { required, obj }: { required: Requireds; obj: Object | Row } = $props();
+	const { required, idPostfix, children }: { required: Requireds; idPostfix: string; children?: any } = $props();
 
 	let modal = $state<'none' | 'appRequirement'>('none');
 	const pointReqOperators = [
@@ -22,170 +17,83 @@
 </script>
 
 <div>
-	<Button onclick={() => (modal = 'appRequirement')} size="icon" variant="ghost">
-		<KeyRound />
-	</Button>
-
-	<div class="flex flex-col gap-y-1 p-2">
-		{#if required.type !== 'pointCompare'}
-			<div class="flex flex-row items-center gap-x-1">
-				<Checkbox
-					id="object-required-show-required-{obj.id}-{required.id}"
-					bind:checked={required.showRequired}
-				/>
-				<Label for="object-required-show-required-{obj.id}-{required.id}">Show Requirement</Label>
-			</div>
-		{/if}
-		{#if required.showRequired && required.type !== 'pointCompare'}
-			<WrappedInput
-				id="object-required-before-text-{obj.id}-{required.id}"
-				label="Text Before"
-				bind:value={required.beforeText}
-			/>
-			<WrappedInput
-				id="object-required-after-text-{obj.id}-{required.id}"
-				label="Text After"
-				bind:value={required.afterText}
-			/>
-		{/if}
-		{#if required.type === 'id'}
-			<WrappedInput
-				id="object-required-id-{obj.id}-{required.id}"
-				label={required.required ? 'Selected ID' : 'Not Selected ID'}
+	{#if required.type === 'id'}
+		<WrappedInput
+				id="object-required-id-{idPostfix}"
+				label={required.required ? 'Selected Choice ID' : 'Not Selected Choice ID'}
 				bind:value={required.reqId}
-			/>
-		{:else if required.type === 'pointCompare'}
-			<span class="text-center">
-				{required.operator.toString() === '1' && 'A is bigger than B'}
-				{required.operator.toString() === '2' && 'A is equal to B'}
-				{required.operator.toString() === '3' && 'A is bigger/equal to B'}
-			</span>
+				placeholder={required.required ? 'Selected ID' : 'Not Selected ID'}
+		/>
+	{:else if required.type === 'points'}
+		<div>
 			<WrappedSelect
-				label="Operator"
-				id="object-required-operator-{obj.id}-{required.id}"
-				bind:value={required.operator}
-				items={pointReqOperators}
-				placeholder="Operator"
+					label="Point Type"
+					id="object-required-pointtype-{idPostfix}"
+					bind:value={required.reqId}
+					items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
+					placeholder="Point Type"
 			/>
 			<WrappedSelect
-				label="Point Type A"
-				id="object-required-pointtype-{obj.id}-{required.id}"
-				bind:value={required.reqId}
-				items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
-				placeholder="Point Type"
+					label="Operator"
+					id="object-required-operator-{idPostfix}"
+					bind:value={required.operator}
+					items={pointReqOperators}
+					placeholder="Operator"
 			/>
-			<WrappedSelect
-				label="Point Type B"
-				id="object-required-pointtype2-{obj.id}-{required.id}"
-				bind:value={required.reqId2}
-				items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
-				placeholder="Point Type"
-			/>
-		{:else if required.type === 'or'}
 			<WrappedInput
-				id="object-required-or-ornum-{obj.id}-{required.id}"
-				label="X"
+					id="object-required-points-{idPostfix}"
+					label="Value"
+					bind:value={required.reqPoints}
+					type="number"
+			/>
+		</div>
+	{:else if required.type === 'pointCompare'}
+		<div>
+						<span class="text-center">
+							{required.operator.toString() === '1' && 'A is bigger than B'}
+							{required.operator.toString() === '2' && 'A is equal to B'}
+							{required.operator.toString() === '3' && 'A is bigger/equal to B'}
+						</span>
+			<WrappedSelect
+					label="Operator"
+					id="object-required-operator-{idPostfix}"
+					bind:value={required.operator}
+					items={pointReqOperators}
+					placeholder="Operator"
+			/>
+			<WrappedSelect
+					label="Point Type A"
+					id="object-required-pointtype-{idPostfix}"
+					bind:value={required.reqId}
+					items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
+					placeholder="Point Type"
+			/>
+			<WrappedSelect
+					label="Point Type B"
+					id="object-required-pointtype2-{idPostfix}"
+					bind:value={required.reqId2}
+					items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
+					placeholder="Point Type"
+			/>
+		</div>
+	{:else if required.type === 'or'}
+		<WrappedInput
+				id="object-required-or-ornum-{idPostfix}"
+				label="N"
 				bind:value={() => required.orNum ?? 1,
-				(v) => (required.orNum = Math.max(0, Math.min(v, required.orRequired.length)))}
+						(v) => (required.orNum = Math.max(0, Math.min(v, required.orRequired.length)))}
 				type="number"
 				min="1"
 				max={required.orRequired.length}
-			/>
-			{#each required.orRequired as orRequired, orIndex}
-				<WrappedInput
-					id="object-required-or-{obj.id}-{required.id}-{orIndex}"
+		/>
+		{#each required.orRequired as orRequired, orIndex}
+			<WrappedInput
+					id="object-required-or-{idPostfix}-{orIndex}"
 					label={required.required ? 'Selected Choice ID' : 'Not Selected Choice ID'}
 					bind:value={orRequired.req}
 					placeholder={required.required ? 'Selected ID' : 'Not Selected ID'}
-				/>
-			{/each}
-		{/if}
-		<div class="grid grid-cols-2">
-			{#each required.requireds as req, index}
-				<div>
-					{#if req.type === 'id'}
-						<WrappedInput
-							id="object-required-id-{obj.id}-{required.id}-{index}"
-							label={required.required ? 'Selected Choice ID' : 'Not Selected Choice ID'}
-							bind:value={req.reqId}
-							placeholder={required.required ? 'Selected ID' : 'Not Selected ID'}
-						/>
-					{:else if req.type === 'points'}
-						<div>
-							<WrappedSelect
-								label="Operator"
-								id="object-required-operator-{obj.id}-{required.id}-{index}"
-								bind:value={req.operator}
-								items={pointReqOperators}
-								placeholder="Operator"
-							/>
-							<WrappedSelect
-								label="Point Type"
-								id="object-required-pointtype-{obj.id}-{required.id}-{index}"
-								bind:value={req.reqId}
-								items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
-								placeholder="Point Type"
-							/>
-							<WrappedInput
-								id="object-required-points-{obj.id}-{required.id}-{index}"
-								label={required.required ? 'More Than' : 'Less Than'}
-								bind:value={required.reqPoints}
-								type="number"
-							/>
-						</div>
-					{:else if req.type === 'pointCompare'}
-						<div>
-							<span class="text-center">
-								{req.operator.toString() === '1' && 'A is bigger than B'}
-								{req.operator.toString() === '2' && 'A is equal to B'}
-								{req.operator.toString() === '3' && 'A is bigger/equal to B'}
-							</span>
-							<WrappedSelect
-								label="Point Type A"
-								id="object-required-pointtype-{obj.id}-{required.id}-{index}"
-								bind:value={req.reqId}
-								items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
-								placeholder="Point Type"
-							/>
-							<WrappedSelect
-								label="Point Type B"
-								id="object-required-pointtype2-{obj.id}-{required.id}-{index}"
-								bind:value={req.reqId2}
-								items={app.pointTypes.map((typ) => ({ value: typ.id, name: typ.name }))}
-								placeholder="Point Type"
-							/>
-						</div>
-					{:else if req.type === 'or'}
-						<WrappedInput
-							id="object-required-or-ornum-{obj.id}-{required.id}-{index}"
-							label="N"
-							bind:value={() => required.orNum ?? 1,
-							(v) => (required.orNum = Math.max(0, Math.min(v, required.orRequired.length)))}
-							type="number"
-							min="1"
-							max={required.orRequired.length}
-						/>
-						{#each req.orRequired as orRequired, orIndex}
-							<WrappedInput
-								id="object-required-or-{obj.id}-{required.id}-{index}-{orIndex}"
-								label={req.required ? 'Selected Choice ID' : 'Not Selected Choice ID'}
-								bind:value={orRequired.req}
-								placeholder={req.required ? 'Selected ID' : 'Not Selected ID'}
-							/>
-						{/each}
-					{/if}
-					<Button
-						onclick={() => {
-							const idx = required.requireds.indexOf(req);
-							required.requireds.splice(idx, 1);
-						}}
-					>
-						Delete
-					</Button>
-				</div>
-			{/each}
-		</div>
-	</div>
-
-	<Requirement open={modal === 'appRequirement'} onclose={() => (modal = 'none')} obj={required} />
+			/>
+		{/each}
+	{/if}
+	{@render children?.()}
 </div>

--- a/src/lib/cyoa/object/ObjectRequirements.svelte
+++ b/src/lib/cyoa/object/ObjectRequirements.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button';
+	import { Checkbox } from '$lib/components/ui/checkbox';
+	import { Label } from '$lib/components/ui/label';
+	import type { Object, Requireds, Row } from '$lib/store/types';
+	import { KeyRound } from 'lucide-svelte';
+	import Requirement from '../row/Requirement.svelte';
+	import WrappedInput from '$lib/components/wrapped/WrappedInput.svelte';
+	import ObjectRequirement from "$lib/cyoa/object/ObjectRequirement.svelte";
+
+	const { required, obj }: { required: Requireds; obj: Object | Row } = $props();
+
+	let modal = $state<'none' | 'appRequirement'>('none');
+</script>
+
+<div>
+	<Button onclick={() => (modal = 'appRequirement')} size="icon" variant="ghost">
+		<KeyRound/>
+	</Button>
+
+	<div class="flex flex-col gap-y-1 p-2">
+		{#if required.type !== 'pointCompare'}
+			<div class="flex flex-row items-center gap-x-1">
+				<Checkbox
+						id="object-required-show-required-{obj.id}-{required.id}"
+						bind:checked={required.showRequired}
+				/>
+				<Label for="object-required-show-required-{obj.id}-{required.id}">Show Requirement</Label>
+			</div>
+		{/if}
+		{#if required.showRequired && required.type !== 'pointCompare'}
+			<WrappedInput
+					id="object-required-before-text-{obj.id}-{required.id}"
+					label="Text Before"
+					bind:value={required.beforeText}
+			/>
+			<WrappedInput
+					id="object-required-after-text-{obj.id}-{required.id}"
+					label="Text After"
+					bind:value={required.afterText}
+			/>
+		{/if}
+		<ObjectRequirement {required} idPostfix="{obj.id}-{required.id}">
+			<div class="grid grid-cols-2">
+
+				{#each required.requireds as req, index}
+					<div class="flex flex-col gap-y-1 p-2">
+						<ObjectRequirement required={req} idPostfix="{obj.id}-{required.id}-{index}">
+							<Button
+									onclick={() => {
+							const idx = required.requireds.indexOf(req);
+							required.requireds.splice(idx, 1);
+						}}
+							>
+								Delete
+							</Button>
+						</ObjectRequirement>
+					</div>
+				{/each}
+			</div>
+		</ObjectRequirement>
+
+	</div>
+</div>
+
+<Requirement open={modal === 'appRequirement'} onclose={() => (modal = 'none')} obj={required}/>


### PR DESCRIPTION
Closes #15 

The Html for handling simple point requirements was already there, but only for nested requirements. To reduce copy paste issues like that (and because I'm lazy) I pulled the pretty much identical code into a component and re-used it inside itself to keep the nested and top level requirements code in sync