### PR TITLE
global design modals now open properly

### DIFF
--- a/src/lib/cyoa/ImageCYOA.svelte
+++ b/src/lib/cyoa/ImageCYOA.svelte
@@ -279,61 +279,51 @@
 				<Filter
 					open={appMetaState.currentDesignComponent === 'appFilter'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appBackground'}
 				<Background
 					open={appMetaState.currentDesignComponent === 'appBackground'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appMultiChoice'}
 				<MultiChoice
 					open={appMetaState.currentDesignComponent === 'appMultiChoice'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appObjectDesign'}
 				<ObjectDesign
 					open={appMetaState.currentDesignComponent === 'appObjectDesign'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appObjectImage'}
 				<ObjectImage
 					open={appMetaState.currentDesignComponent === 'appObjectImage'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appPointBar'}
 				<PointBar
 					open={appMetaState.currentDesignComponent === 'appPointBar'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appRowDesign'}
 				<RowDesign
 					open={appMetaState.currentDesignComponent === 'appRowDesign'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appRowImage'}
 				<RowImage
 					open={appMetaState.currentDesignComponent === 'appRowImage'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appText'}
 				<Text
 					open={appMetaState.currentDesignComponent === 'appText'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{:else if appMetaState.currentDesignComponent === 'appBackpack'}
 				<Backpack
 					open={appMetaState.currentDesignComponent === 'appBackpack'}
 					onclose={() => (appMetaState.currentDesignComponent = 'none')}
-					embedded={true}
 				/>
 			{/if}
 		</div>


### PR DESCRIPTION
The "global design" editors opened in the background due to the "embedded" flag being on
![chrome_2025-03-19_21-50-39_157720f54fa06ed](https://github.com/user-attachments/assets/0e455a5c-8ed6-4537-a930-4107e84f7f31)
