### PR TITLE
compensate non existing values for checkboxes

### DIFF
--- a/src/lib/components/ui/checkbox/checkbox.svelte
+++ b/src/lib/components/ui/checkbox/checkbox.svelte
@@ -6,11 +6,21 @@
 
 	let {
 		ref = $bindable(null),
-		checked = $bindable(false),
-		indeterminate = $bindable(false),
+		checked = $bindable(),
+		indeterminate = $bindable(),
 		class: className,
 		...restProps
 	}: WithoutChildrenOrChild<CheckboxPrimitive.RootProps> = $props();
+
+	const set_default = () => {
+		if (checked === undefined) 
+			checked = false;
+		
+		if (indeterminate === undefined) 
+			indeterminate = false;
+	};
+
+	$effect.pre(set_default);
 </script>
 
 <CheckboxPrimitive.Root

--- a/src/lib/components/ui/switch/switch.svelte
+++ b/src/lib/components/ui/switch/switch.svelte
@@ -5,9 +5,16 @@
 	let {
 		ref = $bindable(null),
 		class: className,
-		checked = $bindable(false),
+		checked = $bindable(),
 		...restProps
 	}: WithoutChildrenOrChild<SwitchPrimitive.RootProps> = $props();
+
+	const set_default = () => {
+		if (checked === undefined)
+			checked = false;
+	};
+
+	$effect.pre(set_default);
 </script>
 
 <SwitchPrimitive.Root


### PR DESCRIPTION
Closes #8 

icc+ ommits some boolean values for the private styling when they are false. Svelte's bind syntax does not allow "undefined" to be bound and throws when it sees it. The easiest and quickest way I found without having to move away from `$bindable` is to assign a default value of false inside the checkbox components. 

Maybe in the future the same must be done for other input types but this is better than before.